### PR TITLE
Remove redundant configuration in authorization-server.md

### DIFF
--- a/authorization-server.md
+++ b/authorization-server.md
@@ -211,8 +211,8 @@ public class TweeterApiApplication {
 		@Override
 		public void configure(HttpSecurity http) throws Exception {
 			// [2]
-			http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-					.and().authorizeRequests().antMatchers(HttpMethod.GET, "/v1/**")
+			http.authorizeRequests()
+					.antMatchers(HttpMethod.GET, "/v1/**")
 					.access("#oauth2.hasScope('tweet.read')")
 					.antMatchers(HttpMethod.POST, "/v1/**")
 					.access("#oauth2.hasScope('tweet.write')")


### PR DESCRIPTION
セッションの生成ポリシーを`STATELESS`にする処理は、`@EnableResourceServer`を指定した時にインポートされる`ResourceServerConfiguration`クラスの`configure(HttpSecurity)`メソッドの中で行われているからここで指定しなくても大丈夫っすよ。
